### PR TITLE
Do not fail even if init target already exists

### DIFF
--- a/src/imp/langs/rust.rs
+++ b/src/imp/langs/rust.rs
@@ -161,6 +161,11 @@ fn create_project_directory(path: &Path) -> Result<()> {
 }
 
 fn generate_git(repository: &str, branch: &str) -> Result<()> {
+    if Path::new("main").exists() {
+        // skip generating everything if main directory exists
+        return Ok(());
+    }
+
     let output = Command::new("cargo")
         .arg("generate")
         .arg("--git")


### PR DESCRIPTION
It's common to use `procon-assistant init` to open the existing directory when
it's used with C++, because C++ generator skips generating already existing
files. So does it in Rust.